### PR TITLE
Handle geojson content in config.json

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -776,7 +776,7 @@ def read_config_file(config_file):
 
     # ROI paths
     for k in ["roi_kml", "roi_geojson"]:
-        if k in user_cfg and not os.path.isabs(user_cfg[k]):
+        if k in user_cfg and isinstance(user_cfg[k], str) and not os.path.isabs(user_cfg[k]):
             user_cfg[k] = make_path_relative_to_file(user_cfg[k], config_file)
 
     # input paths

--- a/s2p/rpc_utils.py
+++ b/s2p/rpc_utils.py
@@ -323,25 +323,34 @@ def kml_roi_process(rpc, kml):
 def geojson_roi_process(rpc, geojson):
     """
     Define a rectangular bounding box in image coordinates
-    from a polygon in a geojson file
+    from a polygon in a geojson file or dict
 
     Args:
         rpc: instance of the rpc_model.RPCModel class, or path to the xml file
-        geojson: file path to a geojson file containing a single polygon
+        geojson: file path to a geojson file containing a single polygon,
+            or content of the file as a dict.
+            The geojson's top-level type should be either FeatureCollection,
+            Feature, or Polygon.
 
     Returns:
         x, y, w, h: four integers defining a rectangular region of interest
             (ROI) in the image. (x, y) is the top-left corner, and (w, h)
             are the dimensions of the rectangle.
     """
-    # extract lon lat from geojson
-    with open(geojson, 'r') as f:
-        a = json.load(f)
+    # extract lon lat from geojson file or dict
+    if isinstance(geojson, str):
+        with open(geojson, 'r') as f:
+            a = json.load(f)
+    else:
+        a = geojson
 
     if a["type"] == "FeatureCollection":
         a = a["features"][0]
 
-    ll_poly = np.array(a["geometry"]["coordinates"][0])
+    if a["type"] == "Feature":
+        a = a["geometry"]
+
+    ll_poly = np.array(a["coordinates"][0])
     box_d = roi_process(rpc, ll_poly)
     return box_d
 


### PR DESCRIPTION
This enables the user to put the contents of the geojson directly inside the `config.json` instead of having to write it to disk.

Also, the code now handles more generic formats of geojson's: the top-level type of the file/dict can be either `FeatureCollection`, `Feature`, or `Polygon`.