### PR TITLE
Simplify MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,113 +1,29 @@
 include README.md
 include makefile
-include c/*.c
-include c/*.h
-include c/*.cpp
-include c/egm96-15.pgm
-include c/homography/Makefile
-include c/homography/linalg.c
-include c/homography/main.cpp
-include c/homography/pickopt.c
-include c/homography/LibHomography/*.cpp
-include c/homography/LibHomography/*.h
-include c/homography/LibImages/*.cpp
-include c/homography/LibImages/*.h
-include c/homography/Utilities/*.cpp
-include c/homography/Utilities/*.h
-include c/sift/Makefile
-include c/sift/linalg.c
-include c/sift/matching.c
-include c/sift/pickopt.c
-include c/sift/timing.c
-include c/sift/sift4ctypes.cpp
-include c/sift/sift_anatomy_20141201/*
-include c/sift/Utilities/*.cpp
-include c/sift/Utilities/*.h
-include c/sift/LibSift/*.cpp
-include c/sift/LibSift/*.h
-include c/sift/LibSSE/*.cpp
-include c/sift/LibSSE/*.h
-include c/sift/LibImages/*.cpp
-include c/sift/LibImages/*.h
+
+recursive-include c *.c *.h *.cpp *.pgm Makefile
+prune c/msmw
+prune c/test_colormesh
+
 include 3rdparty/iio/iio.c
 include 3rdparty/iio/iio.h
-include 3rdparty/mgm_multi/refine.h
-include 3rdparty/mgm_multi/abstract_dsf.c
-include 3rdparty/mgm_multi/mgm_core.cc
-include 3rdparty/mgm_multi/main_mgm.cc
-include 3rdparty/mgm_multi/shear.h
-include 3rdparty/mgm_multi/dvec.cc
-include 3rdparty/mgm_multi/CMakeLists.txt
-include 3rdparty/mgm_multi/mgm_costvolume.cc
-include 3rdparty/mgm_multi/LICENSE
-include 3rdparty/mgm_multi/main_mgm_multi.cc
-include 3rdparty/mgm_multi/point.h
-include 3rdparty/mgm_multi/Makefile
-include 3rdparty/mgm_multi/stereo_utils.h
-include 3rdparty/mgm_multi/mgm_print_energy.h
-include 3rdparty/mgm_multi/point.cc
-include 3rdparty/mgm_multi/img.cc
-include 3rdparty/mgm_multi/stereo_utils.cc
-include 3rdparty/mgm_multi/smartparameter.h
-include 3rdparty/mgm_multi/img.h
-include 3rdparty/mgm_multi/abstract_dsf.h
-include 3rdparty/mgm_multi/mgm_multiscale.cc
-include 3rdparty/mgm_multi/shear.c
-include 3rdparty/mgm_multi/mgm_costvolume.h
-include 3rdparty/mgm_multi/mgm_refine.h
-include 3rdparty/mgm_multi/mgm_core.h
-include 3rdparty/mgm_multi/mgm_weights.h
-include 3rdparty/mgm_multi/mgm_multiscale.h
-include 3rdparty/mgm_multi/img_interp.h
-include 3rdparty/mgm_multi/census_tools.cc
-include 3rdparty/mgm_multi/remove_small_cc.c
-include 3rdparty/mgm_multi/data
-include 3rdparty/mgm_multi/iio
-include 3rdparty/mgm_multi/iio/CMakeLists.txt
-include 3rdparty/mgm_multi/iio/iio_test_named.c
-include 3rdparty/mgm_multi/iio/iio.c
-include 3rdparty/mgm_multi/iio/iioConfig.cmake.in
-include 3rdparty/mgm_multi/iio/FindOPENEXR.cmake
-include 3rdparty/mgm_multi/iio/iio.h
-include 3rdparty/mgm_multi/img_tools.h
-include 3rdparty/mgm/refine.h
-include 3rdparty/mgm/dvec2.cc
-include 3rdparty/mgm/mgm_core.cc
-include 3rdparty/mgm/dvec.cc
-include 3rdparty/mgm/point.h
-include 3rdparty/mgm/Makefile
-include 3rdparty/mgm/mgm_print_energy.h
-include 3rdparty/mgm/point.cc
-include 3rdparty/mgm/img.cc
-include 3rdparty/mgm/mgm.cc
-include 3rdparty/mgm/smartparameter.h
-include 3rdparty/mgm/img.h
-include 3rdparty/mgm/mgm_costvolume.h
-include 3rdparty/mgm/mgm_refine.h
-include 3rdparty/mgm/mgm_weights.h
-include 3rdparty/mgm/census_tools.cc
-include 3rdparty/mgm/iio/CMakeLists.txt
-include 3rdparty/mgm/iio/iio_test_named.c
-include 3rdparty/mgm/iio/iio.c
-include 3rdparty/mgm/iio/iioConfig.cmake.in
-include 3rdparty/mgm/iio/FindOPENEXR.cmake
-include 3rdparty/mgm/iio/iio.h
-include 3rdparty/mgm/img_tools.h
-include 3rdparty/tvl1flow/config.mk
-include 3rdparty/tvl1flow/bicubic_interpolation.c
-include 3rdparty/tvl1flow/zoom.c
-include 3rdparty/tvl1flow/Makefile
-include 3rdparty/tvl1flow/backflow.c
-include 3rdparty/tvl1flow/iio.c
-include 3rdparty/tvl1flow/main.c
-include 3rdparty/tvl1flow/mask.c
-include 3rdparty/tvl1flow/callTVL1.sh
-include 3rdparty/tvl1flow/xmalloc.c
-include 3rdparty/tvl1flow/README.txt
-include 3rdparty/tvl1flow/iio.h
-include 3rdparty/tvl1flow/tvl1flow_lib.c
-include 3rdparty/lsd/Makefile
-include 3rdparty/lsd/lsd.c
-include 3rdparty/lsd/lsd_cmd.c
-include 3rdparty/lsd/lsd.h
-include 3rdparty/lsd/lsd_call_example.c
+
+recursive-include 3rdparty/mgm_multi *
+prune 3rdparty/mgm_multi/data
+prune 3rdparty/mgm_multi/matlab
+
+recursive-include 3rdparty/mgm *
+prune 3rdparty/mgm/data
+prune 3rdparty/mgm/matlab
+
+recursive-include 3rdparty/tvl1flow *
+
+recursive-include 3rdparty/lsd *.c *.h Makefile
+
+include 3rdparty/imscript/Makefile
+recursive-include 3rdparty/imscript/bin *
+recursive-include 3rdparty/imscript/src *
+prune 3rdparty/imscript/src/misc/older
+prune 3rdparty/imscript/src/misc/unused
+
+global-exclude .git .travis.yml *.png

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,29 +1,79 @@
 include README.md
 include makefile
 
+# c/
 recursive-include c *.c *.h *.cpp *.pgm Makefile
 prune c/msmw
 prune c/test_colormesh
 
+# 3rdparty
+
+# iio/
 include 3rdparty/iio/iio.c
 include 3rdparty/iio/iio.h
 
+# mgm_multi/
 recursive-include 3rdparty/mgm_multi *
 prune 3rdparty/mgm_multi/data
 prune 3rdparty/mgm_multi/matlab
 
+# mgm/
 recursive-include 3rdparty/mgm *
 prune 3rdparty/mgm/data
 prune 3rdparty/mgm/matlab
 
+# tvl1flow/
 recursive-include 3rdparty/tvl1flow *
 
+# lsd/
 recursive-include 3rdparty/lsd *.c *.h Makefile
 
-include 3rdparty/imscript/Makefile
+# imscript/
+recursive-include 3rdparty/imscript Makefile TARGETS
+include 3rdparty/imscript/src/backflow.c
+include 3rdparty/imscript/src/bicubic.c
+include 3rdparty/imscript/src/bicubic_gray.c
+include 3rdparty/imscript/src/bilinear_interpolation.c
+include 3rdparty/imscript/src/colorcoordsf.c
+include 3rdparty/imscript/src/downsa.c
+include 3rdparty/imscript/src/drawsegment.c
+include 3rdparty/imscript/src/extrapolators.c
+include 3rdparty/imscript/src/fail.c
+include 3rdparty/imscript/src/fancy_image.c
+include 3rdparty/imscript/src/fancy_image.h
+include 3rdparty/imscript/src/getpixel.c
+include 3rdparty/imscript/src/help_stuff.c
+include 3rdparty/imscript/src/homographies.c
+include 3rdparty/imscript/src/homwarp.c
+include 3rdparty/imscript/src/iio.c
+include 3rdparty/imscript/src/iio.h
+include 3rdparty/imscript/src/imprintf.c
+include 3rdparty/imscript/src/marching_interpolation.c
+include 3rdparty/imscript/src/misc/abstract_dsf.c
+include 3rdparty/imscript/src/misc/cldmask.c
+include 3rdparty/imscript/src/misc/drawsegment.c
+include 3rdparty/imscript/src/misc/fail.c
+include 3rdparty/imscript/src/misc/iio.h
+include 3rdparty/imscript/src/misc/parsenumbers.c
+include 3rdparty/imscript/src/misc/pickopt.c
+include 3rdparty/imscript/src/misc/remove_small_cc.c
+include 3rdparty/imscript/src/misc/xfopen.c
+include 3rdparty/imscript/src/misc/xmalloc.c
+include 3rdparty/imscript/src/morsi.c
+include 3rdparty/imscript/src/parsenumbers.c
+include 3rdparty/imscript/src/pickopt.c
+include 3rdparty/imscript/src/plambda.c
+include 3rdparty/imscript/src/pview.c
+include 3rdparty/imscript/src/qauto.c
+include 3rdparty/imscript/src/random.c
+include 3rdparty/imscript/src/smapa.h
+include 3rdparty/imscript/src/spline.c
+include 3rdparty/imscript/src/synflow.c
+include 3rdparty/imscript/src/synflow_core.c
+include 3rdparty/imscript/src/tiff_octaves_rw.c
+include 3rdparty/imscript/src/vvector.h
+include 3rdparty/imscript/src/xfopen.c
+include 3rdparty/imscript/src/xmalloc.c
 recursive-include 3rdparty/imscript/bin *
-recursive-include 3rdparty/imscript/src *
-prune 3rdparty/imscript/src/misc/older
-prune 3rdparty/imscript/src/misc/unused
 
 global-exclude .git .travis.yml *.png

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -75,5 +75,7 @@ include 3rdparty/imscript/src/vvector.h
 include 3rdparty/imscript/src/xfopen.c
 include 3rdparty/imscript/src/xmalloc.c
 recursive-include 3rdparty/imscript/bin *
+prune 3rdparty/imscript/src/ftr
+prune 3rdparty/imscript/src/misc/older
 
-global-exclude .git .travis.yml *.png
+global-exclude .git .travis.yml *.png *.o *.so


### PR DESCRIPTION
The `MANIFEST.in` was simplified by using globbing include and exclude patterns instead of including files one by one.

Also fixes an issue that was due to `imscript` not being present in the `MANIFEST.in`.

Commit 2c9f637 has a minimal `MANIFEST.in`, but has the disadvantage of generating a `.tar.gz` (when running `python setup.py sdist`) larger than necessary, because it includes all of `imscript`.

Commit 2f0f964 should be the bare minimum `imscript` requirements to be able to make the scripts that are found in `s2p/makefile`.

Before this PR, the `.tar.gz` weighed around 2.2M (but it was incomplete since it did not contain `imscript` at all).
At commit 2c9f637, it weighs around 4.5M (all of `imscript`).
At commit 2c9f637, it weighs around 2.4M (only part of `imscript`).