### PR TITLE
Make Dockerfile install from s2p sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,19 @@ RUN apt-get update && apt-get install -y \
     libgdal-dev \
     libgeographic-dev \
     libgeotiff-dev \
+    libgsl-dev \
     libtiff5-dev \
     python3 \
     python3-numpy \
     python3-pip
 
+# Copy files needed to install s2p
+WORKDIR /root
+COPY LICENSE.txt MANIFEST.in README.md setup.py makefile s2p/
+WORKDIR /root/s2p
+COPY 3rdparty/ 3rdparty/
+COPY c/ c/
+COPY s2p/ s2p/
+
 # Install s2p
-RUN pip3 install s2p
+RUN pip3 install -e .


### PR DESCRIPTION
To be sure to have a docker image with the latest code in it, the `Dockerfile` has been changed to install `s2p` from source instead of from `pip`.

The missing `libgsl-dev` dependency was also added.