### PR TITLE
Update MANIFEST.in and Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,49 @@
+os: linux
+dist: xenial
 language: python
+python: 3.7
 sudo: required
 fast_finish: true
 
 if: tag IS blank
 
-matrix:
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ppa'
+    packages:
+      - gdal-bin
+      - geographiclib-tools
+      - libfftw3-dev
+      - libgdal-dev
+      - libgeographic-dev
+
+install: pip install -e .
+
+jobs:
   include:
-    - os: linux
-      dist: xenial
+    - stage: packaging
+      name: "Python sdist installation"
+      install: skip
+      script:
+        - python setup.py sdist
+        - pip install dist/*.tar.gz
+    - stage: packaging
+      name: "Docker build"
+      addons: skip
+      install: skip
+      script: docker build .
+
+    - stage: test
+      script: pytest --cov=s2p --cov-report term-missing tests
+    - stage: test
       python: 2.7
-    - os: linux
-      dist: xenial
-      python: 3.7
-    - os: osx
+      script: pytest --cov=s2p --cov-report term-missing tests
+    - stage: test
+      os: osx
       language: generic
-
-
-before_install:
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      sudo apt-add-repository -y ppa:ubuntugis/ppa
-      sudo apt-get -qq update
-      sudo apt-get install gdal-bin libfftw3-dev libgdal-dev geographiclib-tools libgeographic-dev
-    fi
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      HOMEBREW_NO_AUTO_UPDATE=1 brew install geographiclib fftw
-    fi
-
-
-install:
-  - |
-    if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      pip install -e .
-    else
-      pip3 install -e .
-    fi
-
-
-script:
-  - pytest --cov=s2p --cov-report term-missing tests
+      # The `homebrew` feature of `addons` is unfortunately not very reliable,
+      # so we `brew install` by hand. See this link for reference on the issue:
+      # https://travis-ci.community/t/osx-homebrew-addons-module-not-as-reliable-as-claimed/4054/7?u=glostis
+      before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install geographiclib fftw
+      script: pytest --cov=s2p --cov-report term-missing tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install -y \
     libgdal-dev \
     libgeographic-dev \
     libgeotiff-dev \
-    libgsl-dev \
     libtiff5-dev \
     python3 \
     python3-numpy \
@@ -24,6 +23,8 @@ WORKDIR /root/s2p
 COPY 3rdparty/ 3rdparty/
 COPY c/ c/
 COPY s2p/ s2p/
+COPY bin/ bin/
+COPY lib/ lib/
 
 # Install s2p
 RUN pip3 install -e .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,9 +2,7 @@ include README.md
 include makefile
 
 # c/
-recursive-include c *.c *.h *.cpp *.pgm Makefile
-prune c/msmw
-prune c/test_colormesh
+recursive-include c *.c *.h *.cpp *.pgm
 
 # 3rdparty
 
@@ -27,6 +25,17 @@ recursive-include 3rdparty/tvl1flow *
 
 # lsd/
 recursive-include 3rdparty/lsd *.c *.h Makefile
+
+# homography/
+recursive-include 3rdparty/homography *
+prune 3rdparty/homography/test_data
+
+# sift/
+recursive-include 3rdparty/sift/simd *
+
+# msmw3/
+recursive-include 3rdparty/msmw3 *
+prune 3rdparty/msmw3/test_data
 
 # imscript/
 recursive-include 3rdparty/imscript Makefile TARGETS
@@ -74,8 +83,11 @@ include 3rdparty/imscript/src/tiff_octaves_rw.c
 include 3rdparty/imscript/src/vvector.h
 include 3rdparty/imscript/src/xfopen.c
 include 3rdparty/imscript/src/xmalloc.c
-recursive-include 3rdparty/imscript/bin *
+include 3rdparty/imscript/bin/.placeholder
 prune 3rdparty/imscript/src/ftr
 prune 3rdparty/imscript/src/misc/older
+
+include bin/.dummy
+include lib/.dummy
 
 global-exclude .git .travis.yml *.png *.o *.so


### PR DESCRIPTION
This PR udpates the `MANIFEST.in` and `Dockerfile` to adapt to PR #18.

In this PR, 3 modules (`sift`, `homography` and `msmw3`) are removed from `c/` and added as `3rdparty` submodules instead.
This PR also changed the `makefile` by removing the creation of the `lib/` and `bin/` folders. so they have to be included in the `MANIFEST.in` and `Dockerfile`.