### PR TITLE
Ensure data is contiguous in memory

### DIFF
--- a/s2p/triangulation.py
+++ b/s2p/triangulation.py
@@ -160,7 +160,7 @@ def count_3d_neighbors(xyz, r, p):
 
     # call the count_3d_neighbors function from disp_to_h.so
     out = np.zeros((h, w), dtype='int32')
-    lib.count_3d_neighbors(out, xyz, w, h, r, p)
+    lib.count_3d_neighbors(out, np.ascontiguousarray(xyz), w, h, r, p)
 
     return out
 


### PR DESCRIPTION
In function count_3d_neighbors, ensure that array xyz is contiguous in
memory (C order) before calling the C function.

While the current implementation is consistent with the rest of the code, when using the function in another context (as I did) it can happen that the memory is not contiguous.
Ensuring that this is always the case might be good in general—and avoid strange result which origin is hard to locate :)