### PR TITLE
Add mgm timeout

### DIFF
--- a/s2p/block_matching.py
+++ b/s2p/block_matching.py
@@ -16,7 +16,7 @@ def rectify_secondary_tile_only(algo):
         return False
 
 def compute_disparity_map(im1, im2, disp, mask, algo, disp_min=None,
-                          disp_max=None, extra_params=''):
+                          disp_max=None, timeout=cfg['mgm_timeout'], extra_params=''):
     """
     Runs a block-matching binary on a pair of stereo-rectified images.
 
@@ -30,6 +30,9 @@ def compute_disparity_map(im1, im2, disp, mask, algo, disp_min=None,
             'msmw', 'tvl1', 'mgm', 'mgm_multi' and 'micmac'
         disp_min : smallest disparity to consider
         disp_max : biggest disparity to consider
+        timeout: time in seconds after which the disparity command will
+            raise an error if it hasn't returned.
+            Only applies to `mgm*` algorithms.
         extra_params: optional string with algorithm-dependent parameters
     """
     if rectify_secondary_tile_only(algo) is False:
@@ -159,7 +162,8 @@ def compute_disparity_map(im1, im2, disp, mask, algo, disp_min=None,
                 im2=im2,
                 disp=disp,
             ),
-            env,
+            env=env,
+            timeout=timeout,
         )
 
         # create rejection mask (0 means rejected, 1 means accepted)
@@ -231,7 +235,8 @@ def compute_disparity_map(im1, im2, disp, mask, algo, disp_min=None,
                 im2=im2,
                 disp=disp,
             ),
-            env,
+            env=env,
+            timeout=timeout,
         )
 
         # create rejection mask (0 means rejected, 1 means accepted)
@@ -274,7 +279,8 @@ def compute_disparity_map(im1, im2, disp, mask, algo, disp_min=None,
                 im2=im2,
                 disp=disp,
             ),
-            env,
+            env=env,
+            timeout=timeout,
         )
 
         # create rejection mask (0 means rejected, 1 means accepted)

--- a/s2p/common.py
+++ b/s2p/common.py
@@ -71,7 +71,7 @@ class RunFailure(Exception):
     pass
 
 
-def run(cmd, env=os.environ):
+def run(cmd, env=os.environ, timeout=None):
     """
     Runs a shell command, and print it before running.
 
@@ -79,6 +79,8 @@ def run(cmd, env=os.environ):
         cmd: string to be passed to a shell
         env (optional, default value is os.environ): dictionary containing the
             environment variables
+        timeout (optional, int): time in seconds after which the function will
+            raise an error if the command hasn't returned
 
     Both stdout and stderr of the shell in which the command is run are those
     of the parent process.
@@ -87,10 +89,10 @@ def run(cmd, env=os.environ):
     t = datetime.datetime.now()
     try:
         subprocess.check_call(cmd, shell=True, stdout=sys.stdout,
-                              stderr=sys.stderr, env=env)
+                              stderr=sys.stderr, env=env, timeout=timeout)
         print(datetime.datetime.now() - t)
 
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         # raise a custom exception because the CalledProcessError causes the
         # pool to crash in python2
         raise RunFailure({"command": e.cmd, "output": e.output})

--- a/s2p/config.py
+++ b/s2p/config.py
@@ -129,8 +129,11 @@ cfg['stereo_speckle_filter'] = 25
 # MGM parameter: regularity (multiplies P1 and P2)
 cfg['stereo_regularity_multiplier'] = 1.0
 
-# MGM parameter: number of directions explored for regularization
+# MGM parameters:
+# number of directions explored for regularization
 cfg['mgm_nb_directions'] = 8
+# timeout in seconds, after which a running mgm process will be killed
+cfg['mgm_timeout'] = 600
 
 # remove isolated 3d points in height maps
 cfg['3d_filtering_r'] = None  # radius in meters

--- a/tests/block_matching_test.py
+++ b/tests/block_matching_test.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+
+import s2p
+from tests_utils import data_path
+
+
+def test_compute_disparity_map_timeout(timeout=1):
+    """
+    Run a long call to compute_disparity_map to check that the timeout kills it.
+    """
+    img = data_path(os.path.join("input_pair", "img_01.tif"))
+    disp = data_path(os.path.join("testoutput", "d.tif"))
+    mask = data_path(os.path.join("testoutput", "m.tif"))
+
+    with pytest.raises(s2p.common.RunFailure):
+        s2p.block_matching.compute_disparity_map(img, img, disp, mask,
+                                                 "mgm_multi", -100, 100,
+                                                 timeout)


### PR DESCRIPTION
This PR adds a timeout to the `mgm*` commands so that the processes running them are effectively killed after a certain time.

The `mgm*` commands are run using the `parallel.launch_calls` function, which opens a pool of processes and runs tasks in them. If the tasks exceed a given timeout (10 minutes), the task is considered as failed, but the underlying process is not killed, which results in memory usage potentially building from execution to execution.

In this PR, a timeout is added to the lower-level `common.run` calls that run `mgm*` so that the processes are killed no matter what.

A few questions:
- Is `mgm_timeout` a good name in the config? Or should it be more generic, even though it currently only applies to `mgm`?
- I don't really see how I could go about adding a test for that feature