### PR TITLE
Remove rasterio test extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ install:
         python3 -m venv venv
         source venv/bin/activate
     fi
-  - pip install -e . --upgrade --upgrade-strategy eager
+  - pip install -e ".[test]" --upgrade --upgrade-strategy eager
 
-script: pytest --cov=s2p --cov-report term-missing tests
+script: pytest tests
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sources, install it in editable mode from a git clone:
 
     git clone https://github.com/cmla/s2p.git --recursive
     cd s2p
-    pip install -e .
+    pip install -e ".[test]"
 
 The `--recursive` option for `git clone` allows to clone all git submodules, such
 as the [iio](https://github.com/mnhrdt/iio) library.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[tool:pytest]
+addopts = --cov s2p --cov-report term-missing
+
+[coverage:run]
+branch = True

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 
 requirements = ['numpy',
                 'scipy',
-                'rasterio[s3,test]>=1.0.14',
+                'rasterio[s3]>=1.0.14',
                 'utm',
                 'pyproj>=2.0.2',
                 'beautifulsoup4[lxml]',
@@ -52,6 +52,10 @@ requirements = ['numpy',
                 'ransac',
                 'rpcm>=1.3',
                 'requests']
+
+extras_require = {
+    "test": ["pytest", "pytest-cov"],
+}
 
 setup(name="s2p",
       version="1.0b21dev",
@@ -61,6 +65,7 @@ setup(name="s2p",
       url='https://github.com/cmla/s2p',
       packages=['s2p'],
       install_requires=requirements,
+      extras_require=extras_require,
       cmdclass={'develop': CustomDevelop,
                 'build_py': CustomBuildPy,
                 'bdist_wheel': BdistWheel},


### PR DESCRIPTION
The `rasterio[test]` extra was there for obscure python2 compatibility reasons.
Now that python2 is no longer supported, it can be removed.

However, removing it exposed the fact that the `test` dependencies of `s2p` were not explicitly listed (as you can see [here](https://github.com/mapbox/rasterio/blob/2d82e06b70313ecb77c6d06356a67e36eaa2c971/setup.py#L364-L366), `pytest` and `pytest-cov` were installed thanks to `rasterio[test]`).
This is now fixed.

Also, the `pytest` arguments were centralized into a `setup.cfg` file so that both the `make test` and `pytest` command in `travis` can use the same arguments.