### PR TITLE
Add CURL_CA_BUNDLE env var to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,6 @@ COPY lib/ lib/
 
 # Install s2p
 RUN pip install -e .
+
+# https://github.com/mapbox/rasterio#ssl-certs
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
This PR adds the `CURL_CA_BUNDLE` environment variable in the Dockerfile.

Without it, `rasterio` raises an error when trying to access remote files.