### PR TITLE
common.run -> shell=False

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN apt-get update && apt-get install -y \
     libgeographic-dev \
     libgeotiff-dev \
     libtiff5-dev \
-    python3 \
-    python3-numpy
+    python3-dev
 
 # Install pip
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py

--- a/s2p/block_matching.py
+++ b/s2p/block_matching.py
@@ -22,8 +22,8 @@ def create_rejection_mask(disp, im1, im2, mask):
     Keep only the points that are matched and present in both input images
 
     Args:
+        disp: path to the input disparity map
         im1, im2: rectified stereo pair
-        disp: path to the input diparity map
         mask: path to the output rejection mask
     """
     tmp1 = common.tmpfile('.tif')

--- a/s2p/common.py
+++ b/s2p/common.py
@@ -376,61 +376,6 @@ def run_binary_on_list_of_points(points, binary, option=None, env_var=None):
     return np.array(out)
 
 
-def get_rectangle_coordinates(im):
-    """
-    Get the coordinates of a rectangle defined by the user's clicks.
-
-    Args:
-        im: path to an image to be displayed.
-
-    Returns:
-        x, y, w, h: coordinates of the rectangle selected by the user. x, y are the
-            coordinates of the top-left corner, while (w, h) is the size of the
-            rectangle.
-    """
-    points_file = tmpfile('.txt')
-    run('python s2p/viewGL.py %s > %s' % (shellquote(im), points_file))
-    x1, y1, x2, y2 = map(int, open(points_file).read().split())
-    # viewGL.py returns the coordinates of two corners defining the rectangle.
-    # We can's make any assumption on the ordering of these coordinates.
-
-    x = min(x1, x2)
-    w = max(x1, x2) - x
-    y = min(y1, y2)
-    h = max(y1, y2) - y
-    return x, y, w, h
-
-
-def get_roi_coordinates(img, preview):
-    """
-    Coordinates of a rectangle in a large image from user clicks on a preview.
-
-    Args:
-        img: path to the large image file
-        preview: path to the preview image file
-
-    Returns:
-        x, y, w, h: coordinates of the rectangle selected by the user, in the
-            large image frame. x, y are the coordinates of the top-left corner,
-            while (w, h) is the size of the rectangle.
-
-    A preview image is displayed, on which the user selects a rectangle.
-    """
-    # read preview/full images dimensions
-    nc, nr = image_size_gdal(img)[:2]
-    nc_preview, nr_preview = image_size_gdal(preview)[:2]
-
-    # get the rectangle coordinates
-    x, y, w, h = get_rectangle_coordinates(preview)
-
-    # rescale according to preview/full ratio
-    x = int(x*nc/nc_preview)
-    y = int(y*nr/nr_preview)
-    w = int(w*nc/nc_preview)
-    h = int(h*nr/nr_preview)
-    return x, y, w, h
-
-
 def cargarse_basura(inputf, outputf):
     se=5
     tmp1 = outputf + '1.tif'

--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -81,10 +81,6 @@ def check_parameters(d):
         # this call defines cfg['utm_zone'] and cfg['utm_bbx'] as side effects
         d['roi'] = rpc_utils.geojson_roi_process(d['images'][0]['rpc'],
                                                  d['roi_geojson'], d.get('utm_zone'))
-    elif 'prv' in d['images'][0]:
-        x, y, w, h = common.get_roi_coordinates(d['images'][0]['img'],
-                                                d['images'][0]['prv'])
-        d['roi'] = {'x': x, 'y': y, 'w': w, 'h': h}
     else:
         print('ERROR: missing or incomplete roi definition')
         sys.exit(1)

--- a/s2p/triangulation.py
+++ b/s2p/triangulation.py
@@ -274,17 +274,18 @@ def height_map_to_point_cloud(cloud, heights, rpc, H=None, crop_colorized='',
     if not os.path.exists(crop_colorized):
         crop_colorized = ''
     hij = " ".join(str(x) for x in H.flatten()) if H is not None else ""
-    asc = "--ascii" if ascii_ply else ""
-    nrm = "--with-normals" if with_normals else ""
-    utm = "--utm-zone %s" % utm_zone if utm_zone else ""
-    lbb = "--lon-m %s --lon-M %s --lat-m %s --lat-M %s" % llbbx if llbbx else ""
-    command = "colormesh %s %s %s %s -h \"%s\" %s %s %s %s" % (cloud, heights,
-                                                               rpcfile,
-                                                               crop_colorized,
-                                                               hij, asc, nrm,
-                                                               utm, lbb)
+    command = ["colormesh", cloud, heights, rpcfile, crop_colorized, "-h", hij]
+    if ascii_ply:
+        command.append("--ascii")
+    if with_normals:
+        command.append("--with-normals")
+    if utm_zone:
+        command.extend(["--utm-zone", utm_zone])
+    if llbbx:
+        lonm, lonM, latm, latM = llbbx
+        command.extend(["--lon-m", lonm, "--lon-M", lonM, "--lat-m", latm, "--lat-M", latM])
     if off_x:
-        command += " --offset_x %d" % off_x
+        command.extend(["--offset_x", "%d" % off_x])
     if off_y:
-        command += " --offset_y %d" % off_y
+        command.extend(["--offset_y", "%d" % off_y])
     common.run(command)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ requirements = ['numpy',
                 'requests']
 
 extras_require = {
-    "test": ["pytest", "pytest-cov"],
+    "test": ["pytest", "pytest-cov", "psutil"],
 }
 
 setup(name="s2p",

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -24,7 +24,7 @@ def test_run_error():
 def test_run_timeout():
     """
     Test s2p.common.run() timeout with Unix "sleep" utility command,
-    and check when the command times out, the launched process is killed.
+    and check that when the command times out, the launched process is killed.
     """
     with pytest.raises(subprocess.TimeoutExpired):
         common.run("sleep 10", timeout=1)

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -1,5 +1,6 @@
 import subprocess
 
+import psutil
 import pytest
 
 from s2p import common
@@ -22,7 +23,16 @@ def test_run_error():
 
 def test_run_timeout():
     """
-    Test s2p.common.run() timeout with Unix "sleep" utility command.
+    Test s2p.common.run() timeout with Unix "sleep" utility command,
+    and check when the command times out, the launched process is killed.
     """
     with pytest.raises(subprocess.TimeoutExpired):
         common.run("sleep 10", timeout=1)
+
+    # Get the names of the running processes
+    proc_names = []
+    for proc in psutil.process_iter(attrs=['pid', 'name']):
+        proc_names.append(proc.info['name'])
+
+    # Check that our process has effectively been killed
+    assert "sleep" not in proc_names

--- a/utils/s2p_mosaic.py
+++ b/utils/s2p_mosaic.py
@@ -233,9 +233,15 @@ def main(tiles_file,outfile,sub_img):
     # If Output format is tif, convert vrt file to tif
     if output_format == 'tif':
         print('Converting vrt to tif ...')
-        common.run(('gdal_translate -ot Float32 -co TILED=YES -co'
-                    ' BIGTIFF=IF_NEEDED %s %s'
-                    %(common.shellquote(vrt_name),common.shellquote(outfile))))
+        common.run(
+            [
+                "gdal_translate",
+                "-ot", "Float32",
+                "-co", "TILED=YES",
+                "-co", "BIGTIFF=IF_NEEDED",
+                vrt_name, outfile,
+            ]
+        )
 
         print('Removing temporary vrt files')
         # Do not use items()/iteritems() here because of python 2 and 3 compat


### PR DESCRIPTION
The current implementation of `common.run` used a `subprocess.check_call` with `shell=True`.

It turns out that this didn't play nicely along with the `timeout` argument across all platforms. On Ubuntu for example, if the timeout is reached, the process running the `shell` is killed, but not the child process of the shell, which runs the actual command (see [the StackOverflow thread](https://stackoverflow.com/a/4789957/9977650) for more information)

The first commit of this PR (f32eafc) adds a test to check if the process running the command is effectively killed, and you can see in [this failing CI](https://travis-ci.com/glostis/s2p/builds/144494758) that it was not the case on Ubuntu.

The solution adopted is to switch `common.run` to a default `shell=False`, which in turn required to refactor a few calls to `common.run` (those that used pipes, and double quotes to escape spaces).

One of the calls could not be refactored because it uses `pview`, a program which only outputs to `stdout`. I've chosen to temporarily add a `shell` optional argument to `common.run` in order for this call only to be run with the previous `shell=True` behavior.

Also, `subprocess.check_call` was replaced with the higher-level `subprocess.run`.

I also took this opportunity to remove a broken option of `s2p`, which enabled the user to pick the ROI graphically on the image preview.