### PR TITLE
Remove except TimeoutError

### DIFF
--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -344,10 +344,11 @@ def tiles_full_info(tw, th, tiles_txt, create_masks=False):
                 images_sizes.append(f.shape)
 
         # compute all masks in parallel as numpy arrays
-        tiles_usefulnesses = parallel.launch_calls_simple(is_this_tile_useful,
-                                                          tiles_coords,
-                                                          cfg['max_processes'],
-                                                          images_sizes)
+        tiles_usefulnesses = parallel.launch_calls(is_this_tile_useful,
+                                                   tiles_coords,
+                                                   cfg['max_processes'],
+                                                   images_sizes,
+                                                   tilewise=False)
 
         # discard useless tiles from neighborhood_coords_dict
         discarded_tiles = set(x for x, (b, _) in zip(tiles_coords, tiles_usefulnesses) if not b)

--- a/s2p/parallel.py
+++ b/s2p/parallel.py
@@ -89,9 +89,6 @@ def launch_calls(fun, list_of_args, nb_workers, *extra_args):
     for r in results:
         try:
             outputs.append(r.get(600))  # wait at most 10 min per call
-        except multiprocessing.TimeoutError:
-            print("Timeout while running %s" % str(r))
-            outputs.append(None)
         except KeyboardInterrupt:
             pool.terminate()
             sys.exit(1)
@@ -132,9 +129,6 @@ def launch_calls_simple(fun, list_of_args, nb_workers, *extra_args):
     for r in results:
         try:
             outputs.append(r.get(600))  # wait at most 10 min per call
-        except multiprocessing.TimeoutError:
-            print("Timeout while running %s" % str(r))
-            outputs.append(None)
         except KeyboardInterrupt:
             pool.terminate()
             sys.exit(1)

--- a/tests/parallel_test.py
+++ b/tests/parallel_test.py
@@ -14,10 +14,10 @@ def raise_exception(t, e):
     raise e
 
 
-def test_launch_calls_simple_error():
+def test_launch_calls_error():
     """
     Run several calls to an erroring function through a multiprocessing.Pool.
     """
     with pytest.raises(subprocess.CalledProcessError):
-        parallel.launch_calls_simple(raise_exception, [1, 1, 1, 1], 2,
-                                     subprocess.CalledProcessError(1, "failcmd"))
+        parallel.launch_calls(raise_exception, [1, 1, 1, 1], 2,
+                              subprocess.CalledProcessError(1, "failcmd"), tilewise=False)


### PR DESCRIPTION
In `s2p.parallel.launch_calls{,_simple}()`, the jobs were run in a ` try: ... except multiprocessing.TimeoutError:` block, which resulted in silent failures if the timeout was reached.

This `except` was removed in order to have a proper error raised if a job times out.

Functions `launch_calls{,_simple}` were also merged into a single function as there was a lot of code duplication between them.