### PR TITLE
Introduce s2p's cfg["images"][?]["rpcm"] key

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -58,9 +58,9 @@ def pointing_correction(tile, i):
     x, y, w, h = tile['coordinates']
     out_dir = os.path.join(tile['dir'], 'pair_{}'.format(i))
     img1 = cfg['images'][0]['img']
-    rpc1 = cfg['images'][0]['rpc']
+    rpc1 = cfg['images'][0]['rpcm']
     img2 = cfg['images'][i]['img']
-    rpc2 = cfg['images'][i]['rpc']
+    rpc2 = cfg['images'][i]['rpcm']
 
     # correct pointing error
     print('correcting pointing on tile {} {} pair {}...'.format(x, y, i))
@@ -113,9 +113,9 @@ def rectification_pair(tile, i):
     out_dir = os.path.join(tile['dir'], 'pair_{}'.format(i))
     x, y, w, h = tile['coordinates']
     img1 = cfg['images'][0]['img']
-    rpc1 = cfg['images'][0]['rpc']
+    rpc1 = cfg['images'][0]['rpcm']
     img2 = cfg['images'][i]['img']
-    rpc2 = cfg['images'][i]['rpc']
+    rpc2 = cfg['images'][i]['rpcm']
     pointing = os.path.join(cfg['out_dir'],
                             'global_pointing_pair_{}.txt'.format(i))
 
@@ -231,8 +231,8 @@ def disparity_to_height(tile, i):
         return
 
     print('triangulating tile {} {} pair {}...'.format(x, y, i))
-    rpc1 = cfg['images'][0]['rpc']
-    rpc2 = cfg['images'][i]['rpc']
+    rpc1 = cfg['images'][0]['rpcm']
+    rpc2 = cfg['images'][i]['rpcm']
     H_ref = np.loadtxt(os.path.join(out_dir, 'H_ref.txt'))
     H_sec = np.loadtxt(os.path.join(out_dir, 'H_sec.txt'))
     disp = os.path.join(out_dir, 'rectified_disp.tif')
@@ -270,8 +270,8 @@ def disparity_to_ply(tile):
     ply_file = os.path.join(out_dir, 'cloud.ply')
     plyextrema = os.path.join(out_dir, 'plyextrema.txt')
     x, y, w, h = tile['coordinates']
-    rpc1 = cfg['images'][0]['rpc']
-    rpc2 = cfg['images'][1]['rpc']
+    rpc1 = cfg['images'][0]['rpcm']
+    rpc2 = cfg['images'][1]['rpcm']
 
     if os.path.exists(os.path.join(out_dir, 'stderr.log')):
         print('triangulation: stderr.log exists')
@@ -441,7 +441,7 @@ def heights_to_ply(tile):
                                                  w, h), colors)
 
     triangulation.height_map_to_point_cloud(plyfile, height_map,
-                                            cfg['images'][0]['rpc'], H, colors,
+                                            cfg['images'][0]['rpcm'], H, colors,
                                             utm_zone=cfg['utm_zone'])
 
     # compute the point cloud extrema (xmin, xmax, xmin, ymax)
@@ -685,7 +685,7 @@ def read_config_file(config_file):
     # input paths
     for img in user_cfg['images']:
         for d in ['img', 'rpc', 'clr', 'cld', 'roi', 'wat']:
-            if d in img and img[d] is not None and not os.path.isabs(img[d]):
+            if d in img and isinstance(img[d], str) and not os.path.isabs(img[d]):
                 img[d] = make_path_relative_to_file(img[d], config_file)
 
     return user_cfg

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = ['numpy',
                 'beautifulsoup4[lxml]',
                 'plyfile',
                 'ransac',
-                'rpcm>=1.3',
+                'rpcm>=1.4.6',
                 'requests']
 
 extras_require = {

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -1,0 +1,107 @@
+import json
+import os
+import shutil
+from unittest.mock import MagicMock
+
+import rasterio
+import rpcm
+
+import pytest
+import s2p
+from tests_utils import data_path
+
+
+@pytest.fixture(name="mocks")
+def fixture_mocks():
+    """
+    Mock functions whose call patterns we want to check
+    """
+    rpcm.rpc_from_geotiff = MagicMock(side_effect=rpcm.rpc_from_geotiff)
+    rpcm.rpc_from_rpc_file = MagicMock(side_effect=rpcm.rpc_from_rpc_file)
+
+
+@pytest.fixture(name="data")
+def fixture_data(tmp_path):
+    """
+    Copy the test data to a temporary directory
+    """
+    img1 = data_path(os.path.join("input_pair", "img_01.tif"))
+    with rasterio.open(img1) as f:
+        rpc1 = rpcm.RPCModel(f.tags(ns="RPC"))
+    shutil.copy(img1, tmp_path / "img_01.tif")
+
+    img2 = data_path(os.path.join("input_pair", "img_02.tif"))
+    with rasterio.open(img2) as f:
+        rpc2 = rpcm.RPCModel(f.tags(ns="RPC"))
+    shutil.copy(img2, tmp_path / "img_02.tif")
+
+    config = data_path(os.path.join("input_pair", "config.json"))
+    tmp_config = tmp_path / "config.json"
+    shutil.copy(config, tmp_config)
+
+    return tmp_config, tmp_path, rpc1, rpc2
+
+
+def test_no_rpc(data, mocks):
+    """
+    Initialize s2p with no `rpc` key.
+    The RPCs should be read from the geotiff tags.
+    """
+
+    tmp_config, _, _, _ = data
+    user_cfg = s2p.read_config_file(tmp_config)
+    s2p.initialization.build_cfg(user_cfg)
+
+    rpcm.rpc_from_geotiff.assert_called()
+    assert rpcm.rpc_from_geotiff.call_count == 2
+    rpcm.rpc_from_rpc_file.assert_not_called()
+
+
+def test_rpc_path(data, mocks):
+    """
+    Initialize s2p with `rpc` keys that are paths to text files.
+    The RPCs should be loaded from the text files.
+    """
+    tmp_config, tmp_path, rpc1, rpc2 = data
+    with open(tmp_config) as f:
+        cfg = json.load(f)
+
+    rpc1_path = str(tmp_path / "rpc1.txt")
+    rpc1.write_to_file(rpc1_path)
+    cfg["images"][0]["rpc"] = rpc1_path
+
+    rpc2_path = str(tmp_path / "rpc2.txt")
+    rpc2.write_to_file(rpc2_path)
+    cfg["images"][1]["rpc"] = rpc2_path
+
+    with open(tmp_config, "w") as f:
+        json.dump(cfg, f)
+
+    user_cfg = s2p.read_config_file(tmp_config)
+    s2p.initialization.build_cfg(user_cfg)
+
+    rpcm.rpc_from_geotiff.assert_not_called()
+    rpcm.rpc_from_rpc_file.assert_called()
+    assert rpcm.rpc_from_rpc_file.call_count == 2
+
+
+def test_rpc_dict(data, mocks):
+    """
+    Initialize s2p with `rpc` keys that are dicts with the RPC contents.
+    The RPCs should be loaded from the dicts.
+    """
+    tmp_config, _, rpc1, rpc2 = data
+    with open(tmp_config) as f:
+        cfg = json.load(f)
+
+    cfg["images"][0]["rpc"] = rpc1.__dict__
+    cfg["images"][1]["rpc"] = rpc2.__dict__
+
+    with open(tmp_config, "w") as f:
+        json.dump(cfg, f)
+
+    user_cfg = s2p.read_config_file(tmp_config)
+    s2p.initialization.build_cfg(user_cfg)
+
+    rpcm.rpc_from_geotiff.assert_not_called()
+    rpcm.rpc_from_rpc_file.assert_not_called()


### PR DESCRIPTION
The `rpcm` key is used to remove the ambiguous nature of the `rpc` key, which was used both by the user to optionally provide the path to a custom RPC file, and internally to store the `RPCModel` instance associated to each image.

The `rpcm` key now stores the `RPCModel` instances, and the `rpc` key has the same use as before.
Thanks to release 1.4.6 of `rpcm` (see https://github.com/cmla/rpcm/pull/9), it is now also possible to provide directly a dict with the RPC values in the `rpc` key.

This PR also fixes two minor bugs:
1. In this line: https://github.com/cmla/s2p/blob/3346ac17fe8ec90d046a5476c1ad9a6c6abcfe37/s2p/initialization.py#L138 `rpc_utils.utm_zone` was called with `rpc=cfg['images'][0]['img']` instead of `rpc=cfg['images'][0]['rpc']`, which would cause problems for images where the RPCs in the geotiff tags were different from the custom RPCs passed by the user. It is now fixed by calling the function with `rpc=cfg['images'][0]['rpcm']`.

2. The `config.json` file written to the output directory of an `s2p` run used to "lose" the information of a custom RPC being passed, because the `rpc` key was being popped before writing the JSON, since the path to the custom RPC had been overwritten by an `RPCModel` instance which is not JSON serializable. This is now fixed by having the `rpc` and the `rpcm` key. The `rpcm` key is still popped, while the `rpc` one is not.