### PR TITLE
Catch erroneous rectification matches

### DIFF
--- a/s2p/rectification.py
+++ b/s2p/rectification.py
@@ -16,6 +16,10 @@ from s2p import block_matching
 from s2p.config import cfg
 
 
+class NoRectificationMatchesError(Exception):
+    pass
+
+
 def filter_matches_epipolar_constraint(F, matches, thresh):
     """
     Discards matches that are not consistent with the epipolar constraint.
@@ -312,6 +316,11 @@ def rectify_pair(im1, im2, rpc1, rpc2, x, y, w, h, out1, out2, A=None, sift_matc
 
     else:
         raise Exception("Unknown value {} for argument 'method'".format(method))
+
+    if matches is None or len(matches) < 4:
+        raise NoRectificationMatchesError(
+            "No or not enough matches found to rectify image pair"
+        )
 
     # compute rectifying homographies
     H1, H2, F = rectification_homographies(matches, x, y, w, h)

--- a/tests/rectification_test.py
+++ b/tests/rectification_test.py
@@ -1,20 +1,104 @@
 import os
+
 import numpy as np
+import pytest
+from rpcm import rpc_from_geotiff
 
 import s2p
 from tests_utils import data_path
 
 
-def test_rectification_homographies():
+@pytest.fixture(name='matches')
+def fixture_matches():
+    matches = np.loadtxt(
+        data_path(os.path.join('expected_output', 'units', 'unit_matches_from_rpc.txt'))
+    )
+    return matches
+
+
+@pytest.fixture(name='images')
+def fixture_images():
+    res = []
+    for i in [1, 2]:
+        im = data_path(os.path.join('input_pair', 'img_0{}.tif'.format(i)))
+        rpc = rpc_from_geotiff(im)
+        res.append(im)
+        res.append(rpc)
+    return res
+
+
+def test_rectification_homographies(matches):
     """
     Test for rectification.rectification_homographies().
     """
-    matches = np.loadtxt(data_path(os.path.join('expected_output', 'units',
-                                                'unit_matches_from_rpc.txt')))
-    
     x, y, w, h = 100, 100, 200, 200
     H1, H2, F = s2p.rectification.rectification_homographies(matches, x, y, w, h)
 
     for variable, filename in zip([H1, H2, F], ['H1.txt', 'H2.txt', 'F.txt']):
         expected = np.loadtxt(data_path(os.path.join('expected_output', 'units', filename)))
         np.testing.assert_allclose(variable, expected, rtol=0.01, atol=1e-6, verbose=True)
+
+
+def test_rectify_pair_no_matches(tmp_path, images):
+    """
+    Test running rectification.rectify_pair() where no matches are found.
+    """
+    im1, rpc1, im2, rpc2 = images
+    with pytest.raises(s2p.rectification.NoRectificationMatchesError):
+        s2p.rectification.rectify_pair(
+            im1=im1,
+            im2=im2,
+            rpc1=rpc1,
+            rpc2=rpc2,
+            x=100,
+            y=100,
+            w=200,
+            h=200,
+            out1=str(tmp_path / 'out1.tiff'),
+            out2=str(tmp_path / 'out2.tiff'),
+            sift_matches=None,
+            method='sift',
+        )
+
+
+def test_rectify_pair_few_matches(tmp_path, matches, images):
+    """
+    Test running rectification.rectify_pair() where less than 4 matches are found.
+    """
+    im1, rpc1, im2, rpc2 = images
+    with pytest.raises(s2p.rectification.NoRectificationMatchesError):
+        s2p.rectification.rectify_pair(
+            im1=im1,
+            im2=im2,
+            rpc1=rpc1,
+            rpc2=rpc2,
+            x=100,
+            y=100,
+            w=200,
+            h=200,
+            out1=str(tmp_path / 'out1.tiff'),
+            out2=str(tmp_path / 'out2.tiff'),
+            sift_matches=matches[:3],
+            method='sift',
+        )
+
+
+def test_rectify_pair_with_matches(tmp_path, matches, images):
+    """
+    Test running rectification.rectify_pair() with some matches.
+    """
+    im1, rpc1, im2, rpc2 = images
+    s2p.rectification.rectify_pair(
+        im1=im1,
+        im2=im2,
+        rpc1=rpc1,
+        rpc2=rpc2,
+        x=100,
+        y=100,
+        w=200,
+        h=200,
+        out1=str(tmp_path / 'out1.tiff'),
+        out2=str(tmp_path / 'out2.tiff'),
+        sift_matches=matches,
+        method='sift',
+    )


### PR DESCRIPTION
Raise a clear error when no or too few rectification matches are found in `s2p.rectification.rectify_pairs()`.

Before this PR, the cases where `matches=None` or where `matches` was of length less than 4 were not caught and resulted in obscure errors downstream.