### PR TITLE
Raise on error

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -23,12 +23,10 @@ import sys
 import os.path
 import json
 import datetime
-import argparse
-import numpy as np
 import subprocess
 import multiprocessing
-import collections
-import shutil
+
+import numpy as np
 import rasterio
 
 

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -577,7 +577,7 @@ def main(user_cfg):
     tiles = initialization.tiles_full_info(tw, th, tiles_txt, create_masks=True)
     if not tiles:
         print('ERROR: the ROI is not seen in two images or is totally masked.')
-        return
+        sys.exit(1)
 
     # initialisation: write the list of tilewise json files to outdir/tiles.txt
     with open(tiles_txt, 'w') as f:

--- a/s2p/common.py
+++ b/s2p/common.py
@@ -262,9 +262,10 @@ def points_apply_homography(H, pts):
 
     # convert the input points to homogeneous coordinates
     if len(pts[0]) < 2:
-        print("""points_apply_homography: ERROR the input must be a numpy array
-          of 2D points, one point per line""")
-        return
+        raise ValueError(
+            "The input must be a numpy array"
+            "of 2D points, one point per line"
+        )
     pts = np.hstack((pts[:, 0:2], pts[:, 0:1]*0+1))
 
     # apply the transformation


### PR DESCRIPTION
I've encountered a case where `s2p` silently exited the main function prematurely without an error exit code (leading me to think that everything went fine, when it didn't).

I've therefore replaced the `return` with a `sys.exit(1)` to exit with an error.

I've also looked for other occurrences of such "silent" errors, and replaced a `return` with a `raise` in `points_apply_homography`.

There's also something going on here: https://github.com/cmla/s2p/blob/b330e7837d411fbeb5c4e74a323babbf62e53738/s2p/__init__.py#L70-L74

but I did not edit it as I do not know if it is still intentional to have a silent error here or not.