### PR TITLE
[feature] add use_srtm option

### DIFF
--- a/s2p/config.py
+++ b/s2p/config.py
@@ -107,7 +107,14 @@ cfg['disp_range_method'] = "wider_sift_exogenous"
 cfg['disp_range_exogenous_low_margin'] = -10
 cfg['disp_range_exogenous_high_margin'] = +100
 
-# exogenous dem
+# whether or not to use SRTM DEM (downloaded from internet) to estimate:
+#   - the average ground altitude (to project the input geographic AOI to the
+#     correct place in the input images)
+#   - a reasonable altitude range (to get a better rectification when
+#     "rectification_method" is set to "rpc")
+cfg['use_srtm'] = False
+
+# exogenous dem. If set, it superseeds SRTM.
 cfg['exogenous_dem'] = None
 cfg['exogenous_dem_geoid_mode'] = True
 

--- a/s2p/rpc_utils.py
+++ b/s2p/rpc_utils.py
@@ -245,8 +245,9 @@ def altitude_range(rpc, x, y, w, h, margin_top=0, margin_bottom=0):
         h_M += margin_top
     elif cfg['use_srtm']:
         s = 0.001 / 12  # SRTM90 pixel spacing is 0.001 / 12 degrees
-        lons = np.arange(lon_m, lon_M, s)
-        lats = np.arange(lat_m, lat_M, s)
+        points = [(lon, lat) for lon in np.arange(lon_m, lon_M, s)
+                             for lat in np.arange(lat_m, lat_M, s)]
+        lons, lats = np.asarray(points).T
         alts = srtm4.srtm4(lons, lats)  # TODO use srtm4 nn interpolation option
         h_m = min(alts) + margin_bottom
         h_M = max(alts) + margin_top

--- a/s2p/rpc_utils.py
+++ b/s2p/rpc_utils.py
@@ -243,6 +243,13 @@ def altitude_range(rpc, x, y, w, h, margin_top=0, margin_bottom=0):
                                             lon_m, lon_M, lat_m, lat_M, rpc)
         h_m += margin_bottom
         h_M += margin_top
+    elif cfg['use_srtm']:
+        s = 0.001 / 12  # SRTM90 pixel spacing is 0.001 / 12 degrees
+        lons = np.arange(lon_m, lon_M, s)
+        lats = np.arange(lat_m, lat_M, s)
+        alts = srtm4.srtm4(lons, lats)  # TODO use srtm4 nn interpolation option
+        h_m = min(alts) + margin_bottom
+        h_M = max(alts) + margin_top
     else:
         h_m, h_M = altitude_range_coarse(rpc, cfg['rpc_alt_range_scale_factor'])
 
@@ -393,14 +400,15 @@ def roi_process(rpc, ll_poly, utm_zone=None):
     cfg['utm_bbx'] = (east_min, east_max, nort_min, nort_max)
 
     # project lon lat vertices into the image
-    lon, lat = np.mean(ll_poly, axis=0)
-    z = srtm4.srtm4(lon, lat)
-
-    img_pts = rpc.projection(ll_poly[:, 0], ll_poly[:, 1], z)
-    img_pts = list(zip(*img_pts))
+    if cfg['use_srtm']:
+        lon, lat = np.mean(ll_poly, axis=0)
+        z = srtm4.srtm4(lon, lat)
+        img_pts = rpc.projection(ll_poly[:, 0], ll_poly[:, 1], z)
+    else:
+        img_pts = rpc.projection(ll_poly[:, 0], ll_poly[:, 1], rpc.alt_offset)
 
     # return image roi
-    x, y, w, h = common.bounding_box2D(img_pts)
+    x, y, w, h = common.bounding_box2D(list(zip(*img_pts)))
     return {'x': x, 'y': y, 'w': w, 'h': h}
 
 

--- a/s2p/rpc_utils.py
+++ b/s2p/rpc_utils.py
@@ -12,6 +12,7 @@ import rasterio
 import numpy as np
 
 import rpcm
+import srtm4
 
 from s2p import geographiclib
 from s2p import common
@@ -392,7 +393,10 @@ def roi_process(rpc, ll_poly, utm_zone=None):
     cfg['utm_bbx'] = (east_min, east_max, nort_min, nort_max)
 
     # project lon lat vertices into the image
-    img_pts = rpc.projection(ll_poly[:, 0], ll_poly[:, 1], rpc.alt_offset)
+    lon, lat = np.mean(ll_poly, axis=0)
+    z = srtm4.srtm4(lon, lat)
+
+    img_pts = rpc.projection(ll_poly[:, 0], ll_poly[:, 1], z)
     img_pts = list(zip(*img_pts))
 
     # return image roi

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ requirements = ['numpy',
                 'plyfile',
                 'ransac',
                 'rpcm>=1.4.6',
+                'srtm4',
                 'requests']
 
 extras_require = {


### PR DESCRIPTION
The new configuration option `use_srtm` (a key added to the `config.cfg` dictionary) controls whether or not `s2p` uses the SRTM DEM to get initial estimations of the ground altitude. It is disabled by default (i.e. `config.cfg["use_srtm"] = False`).

When enabled, the effects of the `use_srtm` option are:
- if defined with geographic coordinates, the input AOI is projected to the correct place in the reference input image
- the region of the second image that corresponds to the reference image AOI (either defined by the user in image coordinates or obtained by projection of a geographic AOI) is better delimited, resulting in SIFT to run on a smaller image crop
- the blind stereo-rectification obtained with the `rectification_method` option set to `rpc` has better horizontal registration.

SRTM altitude values are obtained through [srtm4](https://pypi.org/project/srtm4/).
