### PR TITLE
use_srtm bugfix

### DIFF
--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -81,11 +81,13 @@ def check_parameters(d):
     elif 'roi_kml' in d:
         # this call defines cfg['utm_zone'] and cfg['utm_bbx'] as side effects
         d['roi'] = rpc_utils.kml_roi_process(d['images'][0]['rpcm'],
-                                             d['roi_kml'], d.get('utm_zone'))
+                                             d['roi_kml'], d.get('utm_zone'),
+                                             d.get('use_srtm'))
     elif 'roi_geojson' in d:
         # this call defines cfg['utm_zone'] and cfg['utm_bbx'] as side effects
         d['roi'] = rpc_utils.geojson_roi_process(d['images'][0]['rpcm'],
-                                                 d['roi_geojson'], d.get('utm_zone'))
+                                                 d['roi_geojson'], d.get('utm_zone'),
+                                                 d.get('use_srtm'))
     else:
         print('ERROR: missing or incomplete roi definition')
         sys.exit(1)

--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -77,7 +77,7 @@ def check_parameters(d):
                                                          'hemisphere',
                                                          'x', 'y', 'w', 'h']):
         d['roi'] = rpc_utils.utm_roi_to_img_roi(d['images'][0]['rpcm'],
-                                                d['roi_utm'])
+                                                d['roi_utm'], d.get('use_srtm'))
     elif 'roi_kml' in d:
         # this call defines cfg['utm_zone'] and cfg['utm_bbx'] as side effects
         d['roi'] = rpc_utils.kml_roi_process(d['images'][0]['rpcm'],


### PR DESCRIPTION
In the context of the `rpc_utils.roi_process()` function, the `s2p.config.cfg` object has not yet been updated with the user's dict, so the `cfg['use_srtm']` variable always has its default value.

This PR fixes this by passing the value of `use_srtm` from the user's dict directly to the `roi_process()` function.

This PR also adds the `use_srtm` interface to `rpc_utils.utm_roi_to_img_roi()` in order for it to be consistent with its `rpc_utils.{kml,geojson}_roi_process()` counterparts.