### PR TITLE
Fix use of mgm_timeout config option

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -200,7 +200,7 @@ def stereo_matching(tile,i):
 
     block_matching.compute_disparity_map(rect1, rect2, disp, mask,
                                          cfg['matching_algorithm'], disp_min,
-                                         disp_max)
+                                         disp_max, timeout=cfg['mgm_timeout'])
 
     # add margin around masked pixels
     masking.erosion(mask, mask, cfg['msk_erosion'])

--- a/s2p/block_matching.py
+++ b/s2p/block_matching.py
@@ -34,7 +34,7 @@ def create_rejection_mask(disp, im1, im2, mask):
 
 
 def compute_disparity_map(im1, im2, disp, mask, algo, disp_min=None,
-                          disp_max=None, timeout=cfg['mgm_timeout'], extra_params=''):
+                          disp_max=None, timeout=600, extra_params=''):
     """
     Runs a block-matching binary on a pair of stereo-rectified images.
 


### PR DESCRIPTION
Python has an early binding mechanism for default arguments. They are evaluated at a function's definition time, not at call time, so the value of `cfg['mgm_timeout']` in the definition of `compute_disparity_map` was not the value potentially overridden by the user in his config.

See https://stackoverflow.com/a/1651284/9977650 for more info on python's evaluation of default arguments

This PR fixes this by passing `timeout=cfg['mgm_timeout']` in the call to `compute_disparity_map` so that the most recent value of `cfg['mgm_timeout']` is used.

The takeaway from this bug is that `cfg['...']` values should not be used as function default arguments, as they will not necessarily have the intended value. I have checked in `s2p`'s codebase and didn't find any other occurrences of this bug.