### PR TITLE
Add option to raise error on large disparity range

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -200,7 +200,8 @@ def stereo_matching(tile,i):
 
     block_matching.compute_disparity_map(rect1, rect2, disp, mask,
                                          cfg['matching_algorithm'], disp_min,
-                                         disp_max, timeout=cfg['mgm_timeout'])
+                                         disp_max, timeout=cfg['mgm_timeout'],
+                                         max_disp_range=cfg['max_disp_range'])
 
     # add margin around masked pixels
     masking.erosion(mask, mask, cfg['msk_erosion'])

--- a/s2p/config.py
+++ b/s2p/config.py
@@ -69,6 +69,9 @@ cfg['sift_match_thresh'] = 0.6
 # disp range expansion facto
 cfg['disp_range_extra_margin'] = 0.2
 
+# Maximum disparity range allowed in block matching
+cfg['max_disp_range'] = None
+
 # estimate rectification homographies either blindly using the rpc data or from
 # the images actual content thanks to sift matches
 cfg['rectification_method'] = 'rpc'  # either 'rpc' or 'sift'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [tool:pytest]
 addopts = --cov s2p --cov-report term-missing
+filterwarnings =
+    ignore::rasterio.errors.NotGeoreferencedWarning
 
 [coverage:run]
 branch = True

--- a/tests/block_matching_test.py
+++ b/tests/block_matching_test.py
@@ -19,3 +19,18 @@ def test_compute_disparity_map_timeout(timeout=1):
         s2p.block_matching.compute_disparity_map(img, img, disp, mask,
                                                  "mgm_multi", -100, 100,
                                                  timeout)
+
+
+def test_compute_disparity_map_max_disp_range(max_disp_range=10):
+    """
+    Run a call to compute_disparity_map with a small max_disp_range
+    to check that an error is raised.
+    """
+    img = data_path(os.path.join("input_pair", "img_01.tif"))
+    disp = data_path(os.path.join("testoutput", "d.tif"))
+    mask = data_path(os.path.join("testoutput", "m.tif"))
+
+    with pytest.raises(s2p.block_matching.MaxDisparityRangeError):
+        s2p.block_matching.compute_disparity_map(img, img, disp, mask,
+                                                 "mgm_multi", -100, 100,
+                                                 max_disp_range=max_disp_range)


### PR DESCRIPTION
This PR adds a new config option `max_disp_range` to raise an error in `s2p.block_matching.compute_disparity_map` if the computed disparity range exceeds the specified maximum range.

The config option is set to `None` by default so as to preserve past behavior.

A `pytest` configuration was also added to silence `rasterio.NotGeoreferencedWarning` from `pytest` reports. This should remove [these](https://travis-ci.com/cmla/s2p/jobs/288040247#L1024-L1045) and [these](https://travis-ci.com/cmla/s2p/jobs/288040247#L1082-L1087) lines.