### PR TITLE
Add config option max_processes_stereo_matching

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -606,7 +606,11 @@ def main(user_cfg):
 
     # matching step:
     print('running stereo matching...')
-    parallel.launch_calls(stereo_matching, tiles_pairs, nb_workers,
+    if cfg['max_processes_stereo_matching'] is not None:
+        nb_workers_stereo = cfg['max_processes_stereo_matching']
+    else:
+        nb_workers_stereo = nb_workers
+    parallel.launch_calls(stereo_matching, tiles_pairs, nb_workers_stereo,
                           timeout=timeout)
 
     if n > 2:

--- a/s2p/config.py
+++ b/s2p/config.py
@@ -38,6 +38,10 @@ cfg['vertical_margin'] = 10  # for regularity
 # max number of processes launched in parallel. None means the number of available cores
 cfg['max_processes'] = None
 
+# max number of processes launched in parallel for stereo_matching
+# Uses the value of cfg['max_processes'] if None
+cfg['max_processes_stereo_matching'] = None
+
 # max number of OMP threads used by programs compiled with openMP
 cfg['omp_num_threads'] = 1
 


### PR DESCRIPTION
This new configuration option adds the possibility to have a different tile-wise multiprocess parallelization specifically for the stereo matching operation because this operation can be memory-intensive in which case the user could want to parallelize it less than the other tile-wise operation.