### PR TITLE
Fix exogenous_dem feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,11 @@ addons:
       - sourceline: 'ppa:ubuntugis/ppa'
     packages:
       - gdal-bin
-      - geographiclib-tools
       - libfftw3-dev
       - libgdal-dev
   homebrew:
     packages:
       # GDAL is already included on osx images
-      - geographiclib
       - fftw
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     cmake \
     gdal-bin \
-    geographiclib-tools \
     libfftw3-dev \
     libgdal-dev \
     libgeotiff-dev \

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ running this command:
 
 Copy it in your `~/.profile`.
 
-## Other dependencies (geographiclib, fftw, libtiff)
+## Other dependencies (fftw, libtiff)
 
 On Ubuntu:
 
-    sudo apt install build-essential geographiclib-tools libfftw3-dev libgeotiff-dev libtiff5-dev
+    sudo apt install build-essential libfftw3-dev libgeotiff-dev libtiff5-dev
 
 On macOS:
 
-    brew install geographiclib fftw libtiff
+    brew install fftw libtiff
 
 
 # Installation

--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -79,7 +79,9 @@ def check_parameters(d):
     elif 'roi_geojson' in d:
         ll_poly = geographiclib.read_lon_lat_poly_from_geojson(d['roi_geojson'])
         d['roi'] = rpc_utils.roi_process(d['images'][0]['rpcm'], ll_poly,
-                                         d.get('use_srtm'))
+                                         use_srtm=d.get('use_srtm'),
+                                         exogenous_dem=d.get('exogenous_dem'),
+                                         exogenous_dem_geoid_mode=d.get('exogenous_dem_geoid_mode'))
     else:
         print('ERROR: missing or incomplete roi definition')
         sys.exit(1)

--- a/tests/rpc_utils_test.py
+++ b/tests/rpc_utils_test.py
@@ -3,6 +3,7 @@
 import os
 import numpy as np
 import rpcm
+import pytest
 
 from s2p import rpc_utils
 from tests_utils import data_path
@@ -25,20 +26,54 @@ def test_matches_from_rpc():
                                atol=0.1, verbose=True)
 
 
-def test_roi_process():
+@pytest.mark.parametrize(
+    "use_srtm, exogenous_dem, exogenous_dem_geoid_mode, expected",
+    [
+        (
+            False,
+            None,
+            True,
+            (271.48531, 1.59019, 407.37861, 413.53010),
+        ),
+        (
+            True,
+            None,
+            True,
+            (353.49632, 296.69818, 408.16015, 413.54849),
+        ),
+        (
+            False,
+            data_path(os.path.join("expected_output", "pair", "dsm.tif")),
+            True,
+            (356.65154, 308.01931, 408.19018, 413.54920)
+        ),
+        (
+            False,
+            data_path(os.path.join("expected_output", "pair", "dsm.tif")),
+            False,
+            (356.46596, 307.35347, 408.18841, 413.54916),
+        ),
+    ],
+)
+def test_roi_process(use_srtm, exogenous_dem, exogenous_dem_geoid_mode, expected):
     """
     Test for rpc_utils.roi_process().
     """
-    rpc = rpcm.rpc_from_geotiff(data_path(os.path.join('input_pair',
-                                                            'img_01.tif')))
-    ll_poly = np.asarray([[55.649517, -21.231542],
-                          [55.651502, -21.231542],
-                          [55.651502, -21.229672],
-                          [55.649517, -21.229672]])
-    computed = [rpc_utils.roi_process(rpc, ll_poly)[k] for k in
-                ['x', 'y', 'w', 'h']]
-    expected = (271.48531909338635,
-                1.5901905457030807,
-                407.3786143153775,
-                413.5301010405019)
+    rpc = rpcm.rpc_from_geotiff(data_path(os.path.join("input_pair", "img_01.tif")))
+    ll_poly = np.asarray(
+        [
+            [55.649517, -21.231542],
+            [55.651502, -21.231542],
+            [55.651502, -21.229672],
+            [55.649517, -21.229672],
+        ]
+    )
+    output = rpc_utils.roi_process(
+        rpc,
+        ll_poly,
+        use_srtm=use_srtm,
+        exogenous_dem=exogenous_dem,
+        exogenous_dem_geoid_mode=exogenous_dem_geoid_mode,
+    )
+    computed = [output[k] for k in ["x", "y", "w", "h"]]
     np.testing.assert_allclose(computed, expected, atol=1e-3)


### PR DESCRIPTION
This PR fixes a few broken or incomplete things about the `exogenous_dem` feature. With this feature, the user can pass the path to a DEM that can be used instead of `srtm4` or the RPC's `alt_offset` for all pre-processing steps that require having a rough estimation of the ROI's altitude.

- expose the `exogenous_dem` option in `roi_process()`; previously the only options were to use SRTM or the RPC's `alt_offset`
- use `pyproj` instead of the (broken) `GeoidEval` to convert heights from geoid to ellipsoid datum
- update `roi_process()` tests