### PR TITLE
Change localization origin

### DIFF
--- a/c/rpc.c
+++ b/c/rpc.c
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <float.h>
 
+#include "fail.c"
 #include "xfopen.c"
 #include "rpc.h"
 
@@ -364,8 +365,8 @@ static void decompose_vector_basis(double a[2], double x[2], double u[2],
 {
 	double det = u[0]*v[1] - u[1]*v[0];
 	if (fabs(det) < FLT_MIN) {
-		fprintf(stderr, "ERROR: the given basis is not a basis\n");
-		fprintf(stderr, "\tu: (%g, %g), v: (%g, %g)\n", u[0], u[1], v[0], v[1]);
+		fail("ERROR: the given basis is not a basis\n"
+		 "\tu: (%g, %g), v: (%g, %g)\n", u[0], u[1], v[0], v[1]);
 	}
 	a[0] =  v[1]*x[0] - v[0]*x[1];
 	a[1] = -u[1]*x[0] + u[0]*x[1];

--- a/c/rpc.c
+++ b/c/rpc.c
@@ -384,7 +384,7 @@ static void eval_nrpc_iterative(double *result,
 	double x1[2];
 	double x2[2];
 	double xf[2] = {x, y};
-	double lon = -1, lat = -1, eps = 2;
+	double lon = -0.1, lat = -0.1, eps = 0.2;
 	eval_nrpci(x0, p, lon, lat, z);
 	eval_nrpci(x1, p, lon + eps, lat, z);
 	eval_nrpci(x2, p, lon, lat + eps, z);

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ requirements = ['numpy',
                 'plyfile',
                 'plyflatten>=0.2.0',
                 'ransac',
-                'rpcm>=1.4.6',
+                'rpcm @ git+https://github.com/cmla/rpcm.git@localization-origin',
                 'srtm4>=1.1.2',
                 'requests']
 


### PR DESCRIPTION
This PR changes the initialization origin of the recursive localization function in `rpc.c`. See https://github.com/cmla/rpcm/pull/11 for the explanation of that change.

It also depends on the `localization-origin` branch of `rpcm`, so it depends on https://github.com/cmla/rpcm/pull/11 being merged.

It also contains a minor fix in `rpc.c` where a `fprintf(error)` is changed to a proper error in order to crash the code.