### PR TITLE
Use double precision for 3D points coordinates

### DIFF
--- a/s2p/triangulation.py
+++ b/s2p/triangulation.py
@@ -150,7 +150,7 @@ def disp_to_xyz(rpc1, rpc2, H1, H2, disp, mask, out_crs=None, img_bbx=None, A=No
         x, y, z = geographiclib.pyproj_transform(lonlatalt[:, 0], lonlatalt[:, 1],
                                                  in_crs, out_crs, lonlatalt[:, 2])
 
-        xyz_array = np.column_stack((x, y, z)).reshape(h, w, 3).astype(np.float32)
+        xyz_array = np.column_stack((x, y, z)).reshape(h, w, 3).astype(np.float64)
     else:
         xyz_array = lonlatalt
 
@@ -205,7 +205,7 @@ def stereo_corresp_to_xyz(rpc1, rpc2, pts1, pts2, out_crs=None):
         x, y, z = geographiclib.pyproj_transform(lonlatalt[:, 0], lonlatalt[:, 1],
                                                  in_crs, out_crs, lonlatalt[:, 2])
 
-        xyz_array = np.column_stack((x, y, z)).astype(np.float32)
+        xyz_array = np.column_stack((x, y, z)).astype(np.float64)
     else:
         xyz_array = lonlatalt
 


### PR DESCRIPTION
Single precision has limited accuracy when representing large numbers: for example, numbers between 4 millions and 8 millions stored in single precision are accurate up to 0.5. See https://en.wikipedia.org/w/index.php?title=Single-precision_floating-point_format

UTM coordinates (`s2p` default output CRS) commonly have northing coordinates ranging up to 10 millions meters. Hence these coordinates need to be represented with double precision.

This was the case in former `s2p` version (up to version `1.0b17`). In PR #16, double precision was mistakenly switched to single precision (my bad). The current PR fixes this bug. Many thanks to Alvaro and @gfacciol for spotting it!