### PR TITLE
Fix 3d filtering

### DIFF
--- a/c/disp_to_h.c
+++ b/c/disp_to_h.c
@@ -132,7 +132,7 @@ void disp_to_lonlatalt(double *lonlatalt, float *err,  // outputs
 }
 
 
-float squared_distance_between_3d_points(float a[3], float b[3])
+float squared_distance_between_3d_points(double a[3], double b[3])
 {
     float x = (a[0] - b[0]);
     float y = (a[1] - b[1]);
@@ -141,13 +141,13 @@ float squared_distance_between_3d_points(float a[3], float b[3])
 }
 
 
-void count_3d_neighbors(int *count, float *xyz, int nx, int ny, float r, int p)
+void count_3d_neighbors(int *count, double *xyz, int nx, int ny, float r, int p)
 {
     // count the 3d neighbors of each point
     for (int y = 0; y < ny; y++)
     for (int x = 0; x < nx; x++) {
         int pos = x + nx * y;
-        float *v = xyz + pos * 3;
+        double *v = xyz + pos * 3;
         int c = 0;
         int i0 = y > p ? -p : -y;
         int i1 = y < ny - p ? p : ny - y - 1;
@@ -155,7 +155,7 @@ void count_3d_neighbors(int *count, float *xyz, int nx, int ny, float r, int p)
         int j1 = x < nx - p ? p : nx - x - 1;
         for (int i = i0; i <= i1; i++)
         for (int j = j0; j <= j1; j++) {
-            float *u = xyz + (x + j + nx * (y + i)) * 3;
+            double *u = xyz + (x + j + nx * (y + i)) * 3;
             float d = squared_distance_between_3d_points(u, v);
             if (d < r*r) {
                 c++;
@@ -167,7 +167,7 @@ void count_3d_neighbors(int *count, float *xyz, int nx, int ny, float r, int p)
 
 
 void remove_isolated_3d_points(
-    float* xyz,  // input (and output) image, shape = (h, w, 3)
+    double* xyz,  // input (and output) image, shape = (h, w, 3)
     int nx,      // width w
     int ny,      // height h
     float r,     // filtering radius, in meters
@@ -306,7 +306,7 @@ int main_count_3d_neighbors(int c, char *v[])
 
     // read input data
     int nx, ny, nch;
-    float *xyz = iio_read_image_float_vec(v[1], &nx, &ny, &nch);
+    double *xyz = iio_read_image_double_vec(v[1], &nx, &ny, &nch);
     if (nch != 3) fprintf(stderr, "xyz image must have 3 channels\n");
     float r = atof(v[2]);
     int p = atoi(v[3]);

--- a/s2p/triangulation.py
+++ b/s2p/triangulation.py
@@ -98,7 +98,7 @@ def disp_to_xyz(rpc1, rpc2, H1, H2, disp, mask, out_crs=None, img_bbx=None, A=No
 
     Returns:
         xyz: array of shape (h, w, 3) where each pixel contains the 3D
-            coordinates of the triangulated point in the coordinate system 
+            coordinates of the triangulated point in the coordinate system
             defined by `out_crs`
         err: array of shape (h, w) where each pixel contains the triangulation
             error
@@ -231,7 +231,7 @@ def count_3d_neighbors(xyz, r, p):
 
     # define the argument types of the count_3d_neighbors function from disp_to_h.so
     lib.count_3d_neighbors.argtypes = (ndpointer(dtype=c_int, shape=(h, w)),
-                                       ndpointer(dtype=c_float, shape=(h, w, 3)),
+                                       ndpointer(dtype=c_double, shape=(h, w, 3)),
                                        c_int, c_int, c_float, c_int)
 
     # call the count_3d_neighbors function from disp_to_h.so
@@ -262,7 +262,7 @@ def remove_isolated_3d_points(xyz, r, p, n, q=1):
     assert d == 3, 'expecting a 3-channels image with shape (h, w, 3)'
 
     lib.remove_isolated_3d_points.argtypes = (
-        ndpointer(dtype=c_float, shape=(h, w, 3)),
+        ndpointer(dtype=c_double, shape=(h, w, 3)),
         c_int, c_int, c_float, c_int, c_int, c_int)
 
     lib.remove_isolated_3d_points(np.ascontiguousarray(xyz), w, h, r, p, n, q)

--- a/tests/data/input_pair/config.json
+++ b/tests/data/input_pair/config.json
@@ -15,5 +15,7 @@
   "tile_size" : 300,
   "disp_range_method" : "sift",
   "msk_erosion": 0,
-  "dsm_resolution": 0.5
+  "dsm_resolution": 0.5,
+  "3d_filtering_r": 5,
+  "3d_filtering_n": 50
 }


### PR DESCRIPTION
Fixes the bug described in issue #85, and enables 3d point cloud filtering in one of the end-to-end tests to make sure that this bug would break the tests.